### PR TITLE
add flake.nix, package.nix and overlay.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /assets
 /tmp
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,109 @@
+{
+  "nodes": {
+    "csprpkgs": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1712271889,
+        "narHash": "sha256-5t8QSUeIyDpHCOB+PnS3wtFqAjNf07X0wZhxZb+J/qk=",
+        "owner": "cspr-rad",
+        "repo": "csprpkgs",
+        "rev": "9d01d5c63ff179ee8c42cdcbf8cf892c96c0a0b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cspr-rad",
+        "repo": "csprpkgs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712192574,
+        "narHash": "sha256-LbbVOliJKTF4Zl2b9salumvdMXuQBr2kuKP5+ZwbYq4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f480f9d09e4b4cf87ee6151eba068197125714de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "csprpkgs": "csprpkgs",
+        "nixpkgs": [
+          "csprpkgs",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "csprpkgs",
+          "rust-overlay"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "csprpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706753617,
+        "narHash": "sha256-ZKqTFzhFwSWFEpQTJ0uXnfJBs5Y/po9/8TK4bzssdbs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "58be43ae223034217ea1bd58c73210644031b687",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "cctl - Bash application to work with a local casper-node network.";
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cspr.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cspr.cachix.org-1:vEZlmbOsmTXkmEi4DSdqNVyq25VPNpmSm6qCs4IuTgE="
+    ];
+  };
+
+  inputs = {
+    csprpkgs.url = "github:cspr-rad/csprpkgs";
+    # We follow csprpkgs/nixpkgs because we want to avoid recompiling its packages
+    # by injecting a different revision of nixpkgs. Most (and the largest)
+    # of the runtime dependencies of cctl are from csprpkgs.
+    nixpkgs.follows = "csprpkgs/nixpkgs";
+    rust-overlay.follows = "csprpkgs/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, csprpkgs, rust-overlay }:
+    let
+      # eachSystem :: [ System ] -> (System -> FlakeOutputs)
+      eachSystem = systems: f:
+        let
+          # Merge together the outputs for all systems.
+          op = attrs: system:
+            let
+              ret = f system;
+              op = attrs: key: attrs //
+                {
+                  ${key} = (attrs.${key} or { })
+                    // { ${system} = ret.${key}; };
+                }
+              ;
+            in
+            builtins.foldl' op attrs (builtins.attrNames ret);
+        in
+        builtins.foldl' op { } systems;
+
+      eachDefaultSystem = eachSystem [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    in
+    {
+      herculesCI.ciSystems = [ "x86_64-linux" "aarch64-linux" ];
+      overlays.default = import ./overlay.nix;
+    }
+    // eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default csprpkgs.overlays.default rust-overlay.overlays.default ]; };
+      in
+      {
+        packages = {
+          inherit (pkgs) cctl;
+          default = pkgs.cctl;
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+
+        checks.format = pkgs.runCommand "format-check" { buildInputs = [ pkgs.nixpkgs-fmt ]; } ''
+          set -euo pipefail
+          cd ${self}
+          nixpkgs-fmt --check .
+          touch $out
+        '';
+      });
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  cctl = final.callPackage ./package.nix { };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,114 @@
+{ casper-client-rs
+, casper-node
+, casper-node-launcher
+, casper-node-contracts
+, coreutils
+, python3
+, writeShellScriptBin
+, symlinkJoin
+, findutils
+, less
+, lsof
+, jq
+}:
+let
+  python = python3.withPackages (ps: with ps; [ supervisor tomlkit toml ]);
+  cspr-bins = symlinkJoin {
+    name = "cspr-bins";
+    paths = [
+      casper-client-rs
+      casper-node
+      casper-node-launcher
+      casper-node-contracts
+    ];
+  };
+  src = ./.;
+  mkCctlCommand = commandName: commandPath: writeShellScriptBin "cctl-${commandName}" ''
+    export CCTL=${src}
+    export CCTL_ASSETS=''${CCTL_ASSETS:-./assets}
+    export CSPR_PATH_TO_RESOURCES=${casper-node.src}/resources
+    export CSPR_PATH_TO_BIN=${cspr-bins}/bin
+    ${builtins.readFile "${src}/cmds/${commandPath}.sh"}
+  '';
+in
+symlinkJoin {
+  name = "cctl";
+  paths = [
+    coreutils
+    python
+    findutils
+    less
+    lsof
+    jq
+    # Infrastructure Commands:
+    # ... network
+    (mkCctlCommand "infra-net-setup" "infra/net/setup")
+    (mkCctlCommand "infra-net-start" "infra/net/start")
+    (mkCctlCommand "infra-net-status" "infra/net/status")
+    (mkCctlCommand "infra-net-stop" "infra/net/stop")
+    (mkCctlCommand "infra-net-teardown" "infra/net/teardown")
+    (mkCctlCommand "infra-net-view-paths" "infra/net/view_paths")
+
+    # ... node control
+    (mkCctlCommand "infra-node-clean" "infra/node/clean")
+    (mkCctlCommand "infra-node-stop" "infra/node/stop")
+    (mkCctlCommand "infra-node-restart" "infra/node/restart")
+
+    # ... node views
+    (mkCctlCommand "infra-node-view-config" "infra/node/view_config")
+    (mkCctlCommand "infra-node-view-error-log" "infra/node/view_log_stderr")
+    (mkCctlCommand "infra-node-view-log" "infra/node/view_log_stdout")
+    (mkCctlCommand "infra-node-view-metrics" "infra/node/view_metrics")
+    (mkCctlCommand "infra-node-view-peers" "infra/node/view_peers")
+    (mkCctlCommand "infra-node-view-peer-count" "infra/node/view_peer_count")
+    (mkCctlCommand "infra-node-view-paths" "infra/node/view_paths")
+    (mkCctlCommand "infra-node-view-ports" "infra/node/view_ports")
+    (mkCctlCommand "infra-node-view-rpc-endpoint" "infra/node/view_rpc_endpoint")
+    (mkCctlCommand "infra-node-view-rpc-schema" "infra/node/view_rpc_schema")
+    (mkCctlCommand "infra-node-view-status" "infra/node/view_status")
+    (mkCctlCommand "infra-node-view-storage" "infra/node/view_storage")
+    (mkCctlCommand "infra-node-write-rpc-schema" "infra/node/write_rpc_schema")
+
+    # Chain commands:
+    # ... awaiting
+    (mkCctlCommand "chain-await-n-blocks" "chain/await/n_blocks")
+    (mkCctlCommand "chain-await-n-eras" "chain/await/n_eras")
+    (mkCctlCommand "chain-await-until-block-n" "chain/await/until_block_n")
+    (mkCctlCommand "chain-await-until-era-n" "chain/await/until_era_n")
+
+    # ... views
+    (mkCctlCommand "chain-view-account" "chain/query/view_account")
+    (mkCctlCommand "chain-view-account-address" "chain/query/view_account_address")
+    (mkCctlCommand "chain-view-account-balance" "chain/query/view_account_balance")
+    (mkCctlCommand "chain-view-account-balances" "chain/query/view_account_balances")
+    (mkCctlCommand "chain-view-account-of-faucet" "chain/query/view_account_of_faucet")
+    (mkCctlCommand "chain-view-account-of-user" "chain/query/view_account_of_user")
+    (mkCctlCommand "chain-view-account-of-validator" "chain/query/view_account_of_validator")
+    (mkCctlCommand "chain-view-auction-info" "chain/query/view_auction_info")
+    (mkCctlCommand "chain-view-block" "chain/query/view_block")
+    (mkCctlCommand "chain-view-block-transfers" "chain/query/view_block_transfers")
+    (mkCctlCommand "chain-view-deploy" "chain/query/view_deploy")
+    (mkCctlCommand "chain-view-era" "chain/query/view_era")
+    (mkCctlCommand "chain-view-era-summary" "chain/query/view_era_summary")
+    (mkCctlCommand "chain-view-genesis-accounts" "chain/query/view_genesis_accounts")
+    (mkCctlCommand "chain-view-genesis-chainspec" "chain/query/view_genesis_chainspec")
+    (mkCctlCommand "chain-view-height" "chain/query/view_height")
+    (mkCctlCommand "chain-view-last-finalized-block" "chain/query/view_last_finalized_block")
+    (mkCctlCommand "chain-view-state-root-hash" "chain/query/view_state_root_hash")
+    (mkCctlCommand "chain-view-view-tip-info" "chain/query/view_tip_info")
+    (mkCctlCommand "chain-view-view-validator-changes" "chain/query/view_validator_changes")
+
+    # Transaction commands:
+    # ... system auction
+    (mkCctlCommand "tx-auction-activate-bid" "tx/auction/activate_bid")
+    (mkCctlCommand "tx-auction-delegate" "tx/auction/delegate")
+    (mkCctlCommand "tx-auction-add-bid" "tx/auction/add_bid")
+    (mkCctlCommand "tx-auction-undelegate" "tx/auction/undelegate")
+    (mkCctlCommand "tx-auction-withdraw-bid" "tx/auction/withdraw_bid")
+
+    # ... system mint
+    (mkCctlCommand "tx-mint-dispatch-transfer" "tx/mint/dispatch_transfer")
+    (mkCctlCommand "tx-mint-dispatch-transfer-batch" "tx/mint/dispatch_transfer_batch")
+    (mkCctlCommand "tx-mint-write-transfer-batch" "tx/mint/write_transfer_batch")
+  ];
+}


### PR DESCRIPTION
Duplicate of https://github.com/casper-network/cctl/pull/9
It's a duplicate because we run CI on this repository. Once the flake.nix is in the default branch, hercules-ci will build all outputs of this flake.